### PR TITLE
Scrape constituency names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,5 @@ gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
-gem 'scraped_page_archive'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,11 +10,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
     coderay (1.1.1)
     colorize (0.8.1)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
     excon (0.52.0)
     execjs (2.7.0)
     faraday (0.9.2)
@@ -22,8 +19,6 @@ GEM
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     fuzzy_match (2.1.0)
-    git (1.3.0)
-    hashdiff (0.3.0)
     hashie (3.4.4)
     httpclient (2.8.2.4)
     method_source (0.8.2)
@@ -38,22 +33,10 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    safe_yaml (1.0.4)
-    scraped_page_archive (0.3.1)
-      git (~> 1.3.0)
-      vcr-archive (~> 0.3.0)
     slop (3.6.0)
     sqlite3 (1.3.11)
     sqlite_magic (0.0.6)
       sqlite3
-    vcr (3.0.3)
-    vcr-archive (0.3.0)
-      vcr (~> 3.0.2)
-      webmock (~> 2.0.3)
-    webmock (2.0.3)
-      addressable (>= 2.3.6)
-      crack (>= 0.3.2)
-      hashdiff
     wikidata-client (0.0.10)
       excon (~> 0.40)
       faraday (~> 0.9)
@@ -70,7 +53,6 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
-  scraped_page_archive
   scraperwiki!
   wikidata-client (~> 0.0.7)
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -116,8 +116,6 @@ class Member
 end
 
 class Khurai
-  attr_reader :members
-
   def members
     Table.new.rows do |r|
       Member.new(r)

--- a/scraper.rb
+++ b/scraper.rb
@@ -8,12 +8,14 @@ require 'open-uri'
 require 'scraped_page_archive/open-uri'
 require 'pry'
 
-class Khurai
-  def members
-    table.xpath('.//tr[td]').map do |tr|
+class Rows
+  attr_reader :data
+
+  def initialize
+    @data = table.xpath('.//tr[td]').map do |tr|
       @tds = tr.xpath('./td')
       @cells = tr_with_district || tr_without_district
-      data
+      row
     end
   end
 
@@ -21,12 +23,12 @@ class Khurai
 
   attr_reader :cells, :tds
 
-  def data
+  def row
     {
       name: name,
       name__mn: name_mn,
       party: party,
-      constituency: constituency,
+      constituency: constituency || 'n/a',
       term: term,
       wikiname: wikiname,
       source: url,
@@ -92,6 +94,24 @@ class Khurai
     cell_text = tds[0].text.strip.gsub("\n", ' — ')
     @current_constituency = cell_text unless cell_text =~ /\d/
     @current_constituency
+  end
+end
+
+class Member
+  attr_reader :data
+
+  def initialize(data)
+    @data = data
+  end
+end
+
+class Khurai
+  attr_reader :members
+
+  def initialize
+    @members = Rows.new.data do |r|
+      Member.new(r)
+    end
   end
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -30,7 +30,6 @@ class Row
   def initialize(tds, constituency)
     @tds = tds
     @constituency = constituency
-    @cells = tr_with_district || tr_without_district
   end
 
   def to_h
@@ -48,16 +47,20 @@ class Row
 
   attr_reader :tds, :cells, :constituency
 
+  def cellmap
+    @cellmap ||= cellmap_with_district || cellmap_without_district
+  end
+
   def name
-    tds[cells[:name]].xpath('.//a').text.strip
+    tds[cellmap[:name]].xpath('.//a').text.strip
   end
 
   def name_mn
-    tds[cells[:name__mn]].text.strip
+    tds[cellmap[:name__mn]].text.strip
   end
 
   def party
-    tds[cells[:party]].text.strip
+    tds[cellmap[:party]].text.strip
   end
 
   def term
@@ -65,10 +68,10 @@ class Row
   end
 
   def wikiname
-    tds[cells[:name]].xpath('.//a[not(@class="new")]/@title').text.strip
+    tds[cellmap[:name]].xpath('.//a[not(@class="new")]/@title').text.strip
   end
 
-  def tr_with_district
+  def cellmap_with_district
     if tds.first[:rowspan]
       {
         name: 2,
@@ -78,7 +81,7 @@ class Row
     end
   end
 
-  def tr_without_district
+  def cellmap_without_district
     unless tds.first[:rowspan]
       {
         name: 1,

--- a/scraper.rb
+++ b/scraper.rb
@@ -8,6 +8,10 @@ require 'open-uri/cached'
 require 'pry'
 
 class Table
+  def initialize(node)
+    @table = node
+  end
+
   def rows
     constituency = nil
     table.xpath('.//tr[td]').map do |tr|
@@ -19,18 +23,7 @@ class Table
 
   private
 
-  def url
-    'https://en.wikipedia.org/wiki/'\
-      'List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016'
-  end
-
-  def page
-    Nokogiri::HTML(open(url).read)
-  end
-
-  def table
-    page.xpath('.//h2/span[text()[contains(.,"Constituency")]]/following::table[1]')
-  end
+  attr_reader :table
 end
 
 class Row
@@ -110,9 +103,24 @@ end
 
 class Khurai
   def members
-    Table.new.rows do |r|
+    Table.new(table).rows do |r|
       Member.new(r)
     end
+  end
+
+  private
+
+  def url
+    'https://en.wikipedia.org/wiki/'\
+      'List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016'
+  end
+
+  def page
+    Nokogiri::HTML(open(url).read)
+  end
+
+  def table
+    page.xpath('.//h2/span[text()[contains(.,"Constituency")]]/following::table[1]')
   end
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -3,9 +3,8 @@
 
 require 'scraperwiki'
 require 'nokogiri'
-require 'open-uri'
+require 'open-uri/cached'
 
-require 'scraped_page_archive/open-uri'
 require 'pry'
 
 class Table

--- a/scraper.rb
+++ b/scraper.rb
@@ -43,18 +43,18 @@ class Row
 
   private
 
-  attr_reader :tds, :cells
+  attr_reader :tds
 
   def name
-    tds[cellmap[:name]].xpath('.//a').text.strip
+    tds[1].xpath('.//a').text.strip
   end
 
   def name_mn
-    tds[cellmap[:name__mn]].text.strip
+    tds[2].text.strip
   end
 
   def party
-    tds[cellmap[:party]].text.strip
+    tds[4].text.strip
   end
 
   def term
@@ -62,15 +62,7 @@ class Row
   end
 
   def wikiname
-    tds[cellmap[:name]].xpath('.//a[not(@class="new")]/@title').text.strip
-  end
-
-  def cellmap
-    {
-      name: 1,
-      name__mn: 2,
-      party: 4,
-    }
+    tds[1].xpath('.//a[not(@class="new")]/@title').text.strip
   end
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -45,10 +45,6 @@ class Row
 
   attr_reader :tds, :cells
 
-  def cellmap
-    @cellmap ||= cellmap_without_district
-  end
-
   def name
     tds[cellmap[:name]].xpath('.//a').text.strip
   end
@@ -69,14 +65,12 @@ class Row
     tds[cellmap[:name]].xpath('.//a[not(@class="new")]/@title').text.strip
   end
 
-  def cellmap_without_district
-    unless tds.first[:rowspan]
-      {
-        name: 1,
-        name__mn: 2,
-        party: 4,
-      }
-    end
+  def cellmap
+    {
+      name: 1,
+      name__mn: 2,
+      party: 4,
+    }
   end
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -16,7 +16,7 @@ class Table
     constituency = nil
     table.xpath('.//tr[td]').map do |tr|
       tds = tr.xpath('./td')
-      constituency = tds.first[:rowspan] ? tds.first.text.strip.gsub("\n",' — ') : constituency
+      constituency = tds.first.text.strip.gsub("\n",' — ') if tds.first[:rowspan]
       Row.new(tds, constituency).to_h
     end
   end

--- a/scraper.rb
+++ b/scraper.rb
@@ -45,10 +45,6 @@ class Khurai
     tds[cells[:party]].text.strip
   end
 
-  def constituency
-    'n/a'
-  end
-
   def term
     '2016'
   end
@@ -90,6 +86,12 @@ class Khurai
       name__mn: 2,
       party: 4,
     }
+  end
+
+  def constituency
+    cell_text = tds[0].text.strip.gsub("\n", ' — ')
+    @current_constituency = cell_text unless cell_text =~ /\d/
+    @current_constituency
   end
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -16,7 +16,7 @@ class Table
     constituency = nil
     table.xpath('.//tr[td]').map do |tr|
       tds = tr.xpath('./td')
-      constituency = tds.first.text.strip.gsub("\n",' — ') if tds.first[:rowspan]
+      constituency = tds.shift.text.strip.gsub("\n",' — ') if tds.first[:rowspan]
       Row.new(tds).to_h.merge(constituency: constituency)
     end
   end

--- a/scraper.rb
+++ b/scraper.rb
@@ -46,7 +46,7 @@ class Row
   attr_reader :tds, :cells
 
   def cellmap
-    @cellmap ||= cellmap_with_district || cellmap_without_district
+    @cellmap ||= cellmap_without_district
   end
 
   def name
@@ -67,16 +67,6 @@ class Row
 
   def wikiname
     tds[cellmap[:name]].xpath('.//a[not(@class="new")]/@title').text.strip
-  end
-
-  def cellmap_with_district
-    if tds.first[:rowspan]
-      {
-        name: 2,
-        name__mn: 3,
-        party: 5,
-      }
-    end
   end
 
   def cellmap_without_district

--- a/scraper.rb
+++ b/scraper.rb
@@ -102,6 +102,10 @@ class Member
 end
 
 class Khurai
+  def initialize(url)
+    @url = url
+  end
+
   def members
     Table.new(table).rows do |r|
       Member.new(r)
@@ -110,10 +114,7 @@ class Khurai
 
   private
 
-  def url
-    'https://en.wikipedia.org/wiki/'\
-      'List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016'
-  end
+  attr_reader :url
 
   def page
     Nokogiri::HTML(open(url).read)
@@ -124,6 +125,9 @@ class Khurai
   end
 end
 
-Khurai.new.members.each do |mem|
+url = 'https://en.wikipedia.org/wiki/'\
+      'List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016'
+
+Khurai.new(url).members.each do |mem|
   ScraperWiki.save_sqlite([:name, :term], mem)
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -17,7 +17,7 @@ class Table
     table.xpath('.//tr[td]').map do |tr|
       tds = tr.xpath('./td')
       constituency = tds.first.text.strip.gsub("\n",' — ') if tds.first[:rowspan]
-      Row.new(tds, constituency).to_h
+      Row.new(tds).to_h.merge(constituency: constituency)
     end
   end
 
@@ -27,9 +27,8 @@ class Table
 end
 
 class Row
-  def initialize(tds, constituency)
+  def initialize(tds)
     @tds = tds
-    @constituency = constituency
   end
 
   def to_h
@@ -39,13 +38,12 @@ class Row
       party: party,
       term: term,
       wikiname: wikiname,
-      constituency: constituency,
     }
   end
 
   private
 
-  attr_reader :tds, :cells, :constituency
+  attr_reader :tds, :cells
 
   def cellmap
     @cellmap ||= cellmap_with_district || cellmap_without_district

--- a/scraper.rb
+++ b/scraper.rb
@@ -8,11 +8,11 @@ require 'open-uri'
 require 'scraped_page_archive/open-uri'
 require 'pry'
 
-class Rows
-  attr_reader :data
+class Table
+  attr_reader :rows
 
   def initialize
-    @data = table.xpath('.//tr[td]').map do |tr|
+    @rows = table.xpath('.//tr[td]').map do |tr|
       @tds = tr.xpath('./td')
       @cells = tr_with_district || tr_without_district
       row
@@ -109,7 +109,7 @@ class Khurai
   attr_reader :members
 
   def initialize
-    @members = Rows.new.data do |r|
+    @members = Table.new.rows do |r|
       Member.new(r)
     end
   end

--- a/scraper.rb
+++ b/scraper.rb
@@ -27,8 +27,8 @@ class Table
 end
 
 class Row
-  def initialize(node, constituency)
-    @node = node
+  def initialize(tds, constituency)
+    @tds = tds
     @constituency = constituency
     @cells = tr_with_district || tr_without_district
   end
@@ -46,18 +46,18 @@ class Row
 
   private
 
-  attr_reader :node, :cells, :constituency
+  attr_reader :tds, :cells, :constituency
 
   def name
-    node[cells[:name]].xpath('.//a').text.strip
+    tds[cells[:name]].xpath('.//a').text.strip
   end
 
   def name_mn
-    node[cells[:name__mn]].text.strip
+    tds[cells[:name__mn]].text.strip
   end
 
   def party
-    node[cells[:party]].text.strip
+    tds[cells[:party]].text.strip
   end
 
   def term
@@ -65,11 +65,11 @@ class Row
   end
 
   def wikiname
-    node[cells[:name]].xpath('.//a[not(@class="new")]/@title').text.strip
+    tds[cells[:name]].xpath('.//a[not(@class="new")]/@title').text.strip
   end
 
   def tr_with_district
-    if node.first[:rowspan]
+    if tds.first[:rowspan]
       {
         name: 2,
         name__mn: 3,
@@ -79,7 +79,7 @@ class Row
   end
 
   def tr_without_district
-    unless node.first[:rowspan]
+    unless tds.first[:rowspan]
       {
         name: 1,
         name__mn: 2,

--- a/scraper.rb
+++ b/scraper.rb
@@ -13,7 +13,7 @@ class Table
     table.xpath('.//tr[td]').map do |tr|
       tds = tr.xpath('./td')
       constituency = tds.first[:rowspan] ? tds.first.text.strip.gsub("\n",' — ') : constituency
-      Row.new(tds, constituency, url).to_h
+      Row.new(tds, constituency).to_h
     end
   end
 
@@ -34,9 +34,8 @@ class Table
 end
 
 class Row
-  def initialize(node, constituency, url)
+  def initialize(node, constituency)
     @node = node
-    @url = url
     @constituency = constituency
     @cells = tr_with_district || tr_without_district
   end
@@ -48,7 +47,6 @@ class Row
       party: party,
       term: term,
       wikiname: wikiname,
-      source: source,
       constituency: constituency,
     }
   end
@@ -75,10 +73,6 @@ class Row
 
   def wikiname
     node[cells[:name]].xpath('.//a[not(@class="new")]/@title').text.strip
-  end
-
-  def source
-    @url
   end
 
   def tr_with_district

--- a/scraper.rb
+++ b/scraper.rb
@@ -89,27 +89,13 @@ class Row
   end
 end
 
-class Member
-  attr_reader :data
-
-  def initialize(data)
-    @data = data
-  end
-
-  def to_h
-    @data.to_h
-  end
-end
-
 class Khurai
   def initialize(url)
     @url = url
   end
 
   def members
-    Table.new(table).rows do |r|
-      Member.new(r)
-    end
+    Table.new(table).rows
   end
 
   private


### PR DESCRIPTION
Scrape member constituency names.

Members are grouped by [district on the wikipedia source page](https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016). The district name is only displayed in the upper most row of each district (in column[0]). When the district name is present, it is stored. When a row is without a district name (column[0] contains an ordinal number), the stored district name is used.
