### PR TITLE
Scrape party list members

### DIFF
--- a/lib/constituency_member.rb
+++ b/lib/constituency_member.rb
@@ -1,4 +1,6 @@
-class ConstituencyMember < NokogiriDocument
+require_relative 'member'
+
+class ConstituencyMember < Member
   field :name do
     tds[-4].xpath('.//a').text.strip
   end
@@ -17,11 +19,5 @@ class ConstituencyMember < NokogiriDocument
 
   field :constituency do
     tds[0].text.strip.gsub("\n", ' — ')
-  end
-
-  private
-
-  def tds
-    @tds ||= noko.css('td')
   end
 end

--- a/lib/constituency_member.rb
+++ b/lib/constituency_member.rb
@@ -1,4 +1,4 @@
-class KhuralMember < NokogiriDocument
+class ConstituencyMember < NokogiriDocument
   field :name do
     tds[-4].xpath('.//a').text.strip
   end

--- a/lib/constituency_member_table.rb
+++ b/lib/constituency_member_table.rb
@@ -1,0 +1,9 @@
+require_relative 'member_table'
+
+class ConstituencyMemberTable < MemberTable
+  field :members do
+    table.xpath('.//tr[td]').map do |tr|
+      KhuralMember.new(tr).to_h
+    end
+  end
+end

--- a/lib/constituency_member_table.rb
+++ b/lib/constituency_member_table.rb
@@ -1,9 +1,10 @@
 require_relative 'member_table'
+require_relative 'constituency_member'
 
 class ConstituencyMemberTable < MemberTable
   field :members do
     table.xpath('.//tr[td]').map do |tr|
-      KhuralMember.new(tr).to_h
+      ConstituencyMember.new(tr).to_h
     end
   end
 end

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -1,0 +1,5 @@
+class Member < NokogiriDocument
+  def tds
+    @tds ||= noko.css('td')
+  end
+end

--- a/lib/member_table.rb
+++ b/lib/member_table.rb
@@ -1,6 +1,5 @@
 require_relative 'nokogiri_document'
 require_relative 'unspanned_table'
-require_relative 'khural_member'
 
 class MemberTable < NokogiriDocument
 

--- a/lib/member_table.rb
+++ b/lib/member_table.rb
@@ -3,11 +3,6 @@ require_relative 'unspanned_table'
 require_relative 'khural_member'
 
 class MemberTable < NokogiriDocument
-  field :members do
-    table.xpath('.//tr[td]').map do |tr|
-      KhuralMember.new(tr).to_h
-    end
-  end
 
   private
 

--- a/lib/party_list_member.rb
+++ b/lib/party_list_member.rb
@@ -1,0 +1,19 @@
+require_relative 'member'
+
+class PartyListMember < Member
+  field :name do
+    tds[0].text.strip
+  end
+
+  field :wikiname do
+    tds[0].xpath('.//a[not(@class="new")]/@title').text.strip
+  end
+
+  field :name_mn do
+    tds[1].text.strip
+  end
+
+  field :party do
+    tds[3].text.strip
+  end
+end

--- a/lib/party_list_member_table.rb
+++ b/lib/party_list_member_table.rb
@@ -1,0 +1,10 @@
+require_relative 'member_table'
+require_relative 'party_list_member'
+
+class PartyListMemberTable < MemberTable
+  field :members do
+    table.xpath('.//tr[td]').map do |tr|
+      PartyListMember.new(tr).to_h
+    end
+  end
+end

--- a/lib/term_page.rb
+++ b/lib/term_page.rb
@@ -1,14 +1,27 @@
 require_relative 'constituency_member_table'
+require_relative 'party_list_member_table'
 require 'nokogiri'
 
 class TermPage < NokogiriDocument
   field :members do
+    constituency_members + party_list_members
+  end
+
+  field :constituency_members do
     ConstituencyMemberTable.new(constituency_member_table).members
+  end
+
+  field :party_list_members do
+    PartyListMemberTable.new(party_list_member_table).members
   end
 
   private
 
   def constituency_member_table
     noko.xpath('.//h2/span[text()[contains(.,"Constituency")]]/following::table[1]')
+  end
+
+  def party_list_member_table
+    noko.xpath('//h2[span[@id="Party_list"]]/following-sibling::table[@class="wikitable"]')
   end
 end

--- a/lib/term_page.rb
+++ b/lib/term_page.rb
@@ -3,12 +3,12 @@ require 'nokogiri'
 
 class TermPage < NokogiriDocument
   field :members do
-    MemberTable.new(table).members
+    MemberTable.new(constituency_member_table).members
   end
 
   private
 
-  def table
+  def constituency_member_table
     noko.xpath('.//h2/span[text()[contains(.,"Constituency")]]/following::table[1]')
   end
 end

--- a/lib/term_page.rb
+++ b/lib/term_page.rb
@@ -3,7 +3,7 @@ require 'nokogiri'
 
 class TermPage < NokogiriDocument
   field :members do
-    MemberTable.new(constituency_member_table).members
+    ConstituencyMemberTable.new(constituency_member_table).members
   end
 
   private

--- a/lib/term_page.rb
+++ b/lib/term_page.rb
@@ -1,4 +1,4 @@
-require_relative 'member_table'
+require_relative 'constituency_member_table'
 require 'nokogiri'
 
 class TermPage < NokogiriDocument


### PR DESCRIPTION
We're not currently catching all members of the 2012 term. Part of the legislature was elected from party lists and the scraper does not scrape the table in which these members are listed.

![screen shot 2016-12-06 at 15 33 34](https://cloud.githubusercontent.com/assets/4107953/20931554/648ab728-bbc9-11e6-8ba6-592ee6415e5f.png)

This PR fixes that by creating classes for the two types of members (constituency and party list) and for the two types of tables in which the members are listed. TermPage now returns all members in its :members field.