### PR TITLE
Rename :name_mn fields to :name__mn

### DIFF
--- a/lib/constituency_member.rb
+++ b/lib/constituency_member.rb
@@ -5,7 +5,7 @@ class ConstituencyMember < Member
     tds[-4].xpath('.//a').text.strip
   end
 
-  field :name_mn do
+  field :name__mn do
     tds[-3].text.strip
   end
 

--- a/lib/party_list_member.rb
+++ b/lib/party_list_member.rb
@@ -9,7 +9,7 @@ class PartyListMember < Member
     tds[0].xpath('.//a[not(@class="new")]/@title').text.strip
   end
 
-  field :name_mn do
+  field :name__mn do
     tds[1].text.strip
   end
 


### PR DESCRIPTION
The Mongolian name of each member should be stored in `name__mn` not `name_mn`.

CSV to Popolo expects 'other names' to start with `name__`